### PR TITLE
Check if a lifespan is given when setting an out going context

### DIFF
--- a/src/WebhookClient.php
+++ b/src/WebhookClient.php
@@ -339,7 +339,7 @@ class WebhookClient extends RichMessage
             $name = $context['name'];
 
             $lifespan = 1;
-            if ($context['lifespan']) {
+            if (isset($context['lifespan'])) {
                 $lifespan = is_numeric($context['lifespan']) ? $context['lifespan'] : null;
             }
 


### PR DESCRIPTION
The previous check couldn’t handle 0 as a lifespan, using isset resolves this issue