### PR TITLE
Add support for Slack testbot

### DIFF
--- a/src/RichMessage/RichMessage.php
+++ b/src/RichMessage/RichMessage.php
@@ -13,15 +13,16 @@ abstract class RichMessage
     protected $requestSource;
 
     protected $v2PlatformMap = [
-        'unspecified' => 'PLATFORM_UNSPECIFIED',
-        'facebook'    => 'FACEBOOK',
-        'slack'       => 'SLACK',
-        'telegram'    => 'TELEGRAM',
-        'kik'         => 'KIK',
-        'skype'       => 'SKYPE',
-        'line'        => 'LINE',
-        'viber'       => 'VIBER',
-        'google'      => 'ACTIONS_ON_GOOGLE',
+        'unspecified'   => 'PLATFORM_UNSPECIFIED',
+        'facebook'      => 'FACEBOOK',
+        'slack'         => 'SLACK',
+        'slack_testbot' => 'SLACK',
+        'telegram'      => 'TELEGRAM',
+        'kik'           => 'KIK',
+        'skype'         => 'SKYPE',
+        'line'          => 'LINE',
+        'viber'         => 'VIBER',
+        'google'        => 'ACTIONS_ON_GOOGLE',
     ];
 
     protected $supportedRichMessagePlatforms = [


### PR DESCRIPTION
Dialogflow allows users to spin up a Slack testbot. The only difference is that the source platform is different. So I added the slack_testbot source to the platform map.

Joren