### PR TITLE
Add capability to specify a fallback text

### DIFF
--- a/src/RichMessage/RichMessage.php
+++ b/src/RichMessage/RichMessage.php
@@ -44,7 +44,7 @@ abstract class RichMessage
     }
 
     /**
-     * Set the fallback text if a request source doesn't support rich messages
+     * Set the fallback text if a request source doesn't support rich messages.
      */
     public function setFallbackText($text)
     {
@@ -56,12 +56,13 @@ abstract class RichMessage
     /**
      * Alias of setFallbackText() to fit more inline with text(), button(), image(), etc.
      */
-    public function fallbackText($text){
+    public function fallbackText($text)
+    {
         return $this->setFallbackText($text);
     }
 
     /**
-     * Get the fallback text
+     * Get the fallback text.
      *
      * @return  string
      */
@@ -69,7 +70,6 @@ abstract class RichMessage
     {
         return $this->fallbackText;
     }
-
 
     protected function setAgentVersion($agentVersion)
     {

--- a/src/RichMessage/RichMessage.php
+++ b/src/RichMessage/RichMessage.php
@@ -11,6 +11,7 @@ abstract class RichMessage
 
     protected $agentVersion;
     protected $requestSource;
+    protected $fallbackText;
 
     protected $v2PlatformMap = [
         'unspecified'   => 'PLATFORM_UNSPECIFIED',
@@ -41,6 +42,34 @@ abstract class RichMessage
     {
         return in_array($this->requestSource, $this->supportedRichMessagePlatforms);
     }
+
+    /**
+     * Set the fallback text if a request source doesn't support rich messages
+     */
+    public function setFallbackText($text)
+    {
+        $this->fallbackText = $text;
+
+        return $this;
+    }
+
+    /**
+     * Alias of setFallbackText() to fit more inline with text(), button(), image(), etc.
+     */
+    public function fallbackText($text){
+        return $this->setFallbackText($text);
+    }
+
+    /**
+     * Get the fallback text
+     *
+     * @return  string
+     */
+    public function getFallbackText()
+    {
+        return $this->fallbackText;
+    }
+
 
     protected function setAgentVersion($agentVersion)
     {

--- a/src/WebhookClient.php
+++ b/src/WebhookClient.php
@@ -297,7 +297,7 @@ class WebhookClient extends RichMessage
                 $this->text = $message;
             }
         } elseif ($message instanceof RichMessage) {
-            if (! $this->doesSupportRichMessage()){
+            if (! $this->doesSupportRichMessage()) {
                 $this->text = $message->getFallbackText();
             }
 

--- a/src/WebhookClient.php
+++ b/src/WebhookClient.php
@@ -297,7 +297,7 @@ class WebhookClient extends RichMessage
                 $this->text = $message;
             }
         } elseif ($message instanceof RichMessage) {
-            if(! $this->doesSupportRichMessage()){
+            if (! $this->doesSupportRichMessage()){
                 $this->text = $message->getFallbackText();
             }
 

--- a/src/WebhookClient.php
+++ b/src/WebhookClient.php
@@ -297,6 +297,10 @@ class WebhookClient extends RichMessage
                 $this->text = $message;
             }
         } elseif ($message instanceof RichMessage) {
+            if(! $this->doesSupportRichMessage()){
+                $this->text = $message->getFallbackText();
+            }
+
             $message->setAgentVersion($this->agentVersion)
                 ->setRequestSource($this->requestSource);
 

--- a/tests/RichMessage/FallbackTextTest.php
+++ b/tests/RichMessage/FallbackTextTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Dialogflow\tests\RichMessage;
+
+use Dialogflow\RichMessage\Card;
+use Dialogflow\WebhookClient;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class FallbackTextTest extends TestCase
+{
+    private $fallbackText = 'This is fallback text';
+
+    protected static function getMethod($name)
+    {
+        $class = new ReflectionClass('Dialogflow\RichMessage\Card');
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    private function getCard(){
+        $Card = Card::create();
+        return $Card;
+    }
+    private function getClient()
+    {
+        $request = [
+            "responseId"  => "123",
+            "queryResult" => [
+                "queryText"                => "fubar",
+                "parameters"               =>[],
+                "allRequiredParamsPresent" => true,
+                "fulfillmentText"          => "fubar",
+                "fulfillmentMessages"      => [
+                    "text" => [
+                        "text" => [
+                            "Fubar"
+                        ]
+                    ]
+                ],
+                "intent" => [
+                    "name"        => "projects/blah/agent/intents/blah",
+                    "displayName" => "Blah"
+                ],
+                "intentDetectionConfidence"   => 1,
+                "languageCode"                => "en"
+            ],
+            "originalDetectIntentRequest" => [
+                "payload" => []
+            ],
+            "session" => "projects/blah/agent/sessions/blah",
+            "alternativeQueryResults" => [
+                [
+                    "queryText"    => "Blah",
+                    "languageCode" => "en"
+                ]
+            ]
+        ];
+
+
+        $Client = new WebhookClient($request);
+
+        $setAgentVersion = self::getMethod('setAgentVersion');
+        $setAgentVersion->invokeArgs($Client, [2]);
+
+        $setRequestSource = self::getMethod('setRequestSource');
+        $setRequestSource->invokeArgs($Client, ['unspecified']);
+
+        return $Client;
+    }
+
+
+    /**
+     * Test that the setFallbackText() method actually sets the value
+     */
+    public function testSetFallbackText()
+    {
+        $Card = $this->getCard();
+        $Card->setFallbackText($this->fallbackText);
+        $this->assertEquals($this->fallbackText,$Card->getFallbackText());
+    }
+
+    /**
+     * Test that the fallbackText() method actually sets the value
+     */
+    public function testFallbackText()
+    {
+        $Card = $this->getCard();
+        $Card->fallbackText($this->fallbackText);
+        $this->assertEquals($this->fallbackText,$Card->getFallbackText());
+    }
+
+    /**
+     * Test that WebhookClient actually falls back to the fallback text,
+     * when the source doesn't support rich messages
+     */
+    public function testReplyFallback(){
+        $Client  = $this->getClient();
+        $Card    = $this->getCard();
+        $Card->fallbackText($this->fallbackText);
+        $Message = $Client->reply($Card);
+
+        $this->assertAttributeEquals($this->fallbackText,'text',$Message);
+    }
+}


### PR DESCRIPTION
The fallback text is used in the response on request sources that don't support rich messages