### PR TITLE
allow usage of carbon v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4",
-        "nesbot/carbon": "^1.25"
+        "nesbot/carbon": "1.* || 2.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi,

As of Laravel 5.8 upgraded Carbon to v2 this package can't be used yet for this Version.

I've added the Version constraint to allow both Versions v1 and v2 of Carbon.

Tests are green so hope you like it.