### PR TITLE
Signalwire SMS gateway expects the fulfillmentText field to be populated

### DIFF
--- a/src/WebhookClient.php
+++ b/src/WebhookClient.php
@@ -515,6 +515,8 @@ class WebhookClient extends RichMessage
 
         if ($this->text) {
             $out['fulfillmentText'] = $this->text;
+        } else if (sizeof($messages) > 0 && is_null($this->text)) {
+            $out['fulfillmentText'] = implode("\n", $messages);
         }
 
         $outgoingContexts = [];


### PR DESCRIPTION
Populates fulfillmentText field when there are multiple items.